### PR TITLE
Add TWZRD Agent Intel to Security & Risk section

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,19 @@ Inspired by [awesome-uniswap-hooks](https://github.com/fewwwww/awesome-uniswap-h
 
 ---
 
+#### [TWZRD Agent Intel](https://intel.twzrd.xyz)
+> Trust-scoring MCP server for x402 agents on Solana. Preflight reputation checks + signed USDC trust receipts for agent-to-agent transactions.
+
+**Modules / Capabilities:**
+- `Trust Preflight` — free reputation score for any Solana agent wallet before transacting
+- `Signed Trust Receipt` — signed on-chain USDC trust receipt, settled in <1s via x402
+- `MCP Server` — Streamable-HTTP at `https://intel.twzrd.xyz/mcp`, no auth needed for free tier
+
+**Access:** MCP (Streamable-HTTP) · Free preflight · Paid receipt via x402  
+**Works with:** Claude Code, any MCP-compatible agent framework
+
+---
+
 ## CeFi Skills
 
 ### [Binance Skills Hub](https://github.com/binance/binance-skills-hub)


### PR DESCRIPTION
## Summary

Adds **TWZRD Agent Intel** to the Security & Risk section.

**What it is:** A trust-scoring MCP server for x402 agents on Solana. Agents in multi-agent Web3 workflows call it to verify counterparty reputation before executing autonomous transactions — solving the trust problem that arises when agents need to transact with unknown wallets.

**Two capabilities:**
1. **Free preflight** — reputation score for any Solana agent wallet, no API key
2. **Paid signed receipt** — on-chain USDC trust receipt settled in <1s via x402 protocol

**Why Security & Risk:** Complements the existing SlowMist MistTrack entry (which focuses on post-hoc threat intelligence and fund tracing) with a *pre-transaction* trust signal specifically for AI agent-to-agent interactions.

**Integration:** Streamable-HTTP MCP server at `https://intel.twzrd.xyz/mcp` — compatible with Claude Code, OpenClaw, and any MCP-capable agent framework.

- Website: https://intel.twzrd.xyz
- GitHub: https://intel.twzrd.xyz